### PR TITLE
fix: inline token completion

### DIFF
--- a/.changeset/green-eggs-joke.md
+++ b/.changeset/green-eggs-joke.md
@@ -1,0 +1,5 @@
+---
+'@pandacss/language-server': patch
+---
+
+Fix inline token completions due to an issue with the settings retrieval

--- a/packages/language-server/src/panda-language-server.ts
+++ b/packages/language-server/src/panda-language-server.ts
@@ -65,7 +65,12 @@ export class PandaLanguageServer {
 
     this.project = new ProjectHelper(getContext)
     this.tokenFinder = new TokenFinder(getContext, this.project)
-    this.completions = new CompletionProvider(getContext, this.getPandaSettings, this.project, this.tokenFinder)
+    this.completions = new CompletionProvider(
+      getContext,
+      this.getPandaSettings.bind(this),
+      this.project,
+      this.tokenFinder,
+    )
 
     this.builderResolver = new BuilderResolver(({ configPath, builder }) => {
       const ctx = builder.context


### PR DESCRIPTION
the settings were outdated, so it never went in the `if settings['completions.token-fn.enabled'])` condition