### PR TITLE
feat: activate on gjs/gts files

### DIFF
--- a/.changeset/smart-cobras-visit.md
+++ b/.changeset/smart-cobras-visit.md
@@ -1,0 +1,5 @@
+---
+"panda-css-vscode": patch
+---
+
+Support extendion activation on `.gjs` and `.gts` files for Next-gen Ember files

--- a/packages/vscode/src/panda-extension.ts
+++ b/packages/vscode/src/panda-extension.ts
@@ -18,6 +18,8 @@ const docSelector: vscode.DocumentSelector = [
   'javascript',
   'javascriptreact',
   'astro',
+  'glimmer-js',
+  'glimmer-ts',
   // TODO re-enable whenever we figured out how to map transformed file AST nodes to their original positions
   // 'svelte',
   // 'vue',


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

## 📝 Description

Actives the VS Code plugin on Glimmer JS/TS files. This is the next-generation component authoring format used by Ember. ([ref](https://guides.emberjs.com/release/components/template-tag-format/))

## ⛳️ Current behavior (updates)

The plugin does nothing in `.gjs` or `.gts` files.

## 🚀 New behavior

The plugin kicks in when editing `.gjs` or `.gts` files.

<img width="481" alt="panda-vsc" src="https://github.com/chakra-ui/panda-vscode/assets/10243652/a7b0990c-6bae-4056-a528-60493682d896">

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information

❤️ 