### PR TITLE
fix: number token values

### DIFF
--- a/packages/language-server/src/tokens/get-token.ts
+++ b/packages/language-server/src/tokens/get-token.ts
@@ -70,7 +70,7 @@ export const getTokenFromPropValue = (ctx: PandaContext, prop: string, value: st
 
   let color = token.value
   // could be a semantic token, so the token.value wouldn't be a color directly, it's actually a CSS variable
-  if (!isColor(color) && token.value.startsWith('var(--')) {
+  if (!isColor(color) && typeof token.value === "string" && token.value.startsWith('var(--')) {
     const [tokenRef] = ctx.tokens.getReferences(token.originalValue)
     if (tokenRef?.value) {
       color = tokenRef.value

--- a/sandbox/vite/panda.config.ts
+++ b/sandbox/vite/panda.config.ts
@@ -17,6 +17,11 @@ export default defineConfig({
       recipes: {
         button,
       },
+      tokens: {
+        lineHeights: {
+          normal: { value: 1.4 }
+        }
+      },
       semanticTokens: {
         colors: {
           danger: {

--- a/sandbox/vite/src/App.tsx
+++ b/sandbox/vite/src/App.tsx
@@ -32,6 +32,7 @@ function App() {
           margin: '2rem',
           padding: '4',
           fontSize: '2xl',
+          lineHeight: 'normal'
         })}
       >
         Hello from Panda !


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

Closes #40 <!-- Github issue # here -->

## 📝 Description

Currently, `panda-vscode` fails with number token values, and this PR fixes the issue.

> Add a brief description

## ⛳️ Current behavior (updates)

<img width="503" alt="image" src="https://github.com/chakra-ui/panda-vscode/assets/250407/db9a2773-7e31-472c-aedc-e9111a4a13ce">

Error

```
handleFailedRequest {type: cu, token: R, error: Error: Request textDocument/documentColor fail…message: T.value.startsWith is not a function…, defaultValue: null, showNotification: undefined}
```


> Please describe the current behavior that you are modifying

## 🚀 New behavior

<img width="463" alt="image" src="https://github.com/chakra-ui/panda-vscode/assets/250407/14844bac-5b88-4ef7-8504-b49d4b6e2c9c">



> Please describe the behavior or changes this PR adds

## 💣 Is this a breaking change (Yes/No):

<!-- If Yes, please describe the impact and migration path for existing Panda users. -->

## 📝 Additional Information
