### PR TITLE
fix: prod output

### DIFF
--- a/.changeset/purple-spiders-flow.md
+++ b/.changeset/purple-spiders-flow.md
@@ -1,0 +1,5 @@
+---
+'panda-css-vscode': patch
+---
+
+Fix the CI build output

--- a/packages/vscode/tsup.config.ts
+++ b/packages/vscode/tsup.config.ts
@@ -11,7 +11,7 @@ const nodeModulesPath = path.resolve(__dirname, 'node_modules')
 export default defineConfig({
   entry: ['src/index.ts', 'src/server.ts'],
   format: ['cjs'],
-  external: ['vscode', 'esbuild', 'lightningcss', '@vue/compiler-sfc'],
+  external: ['vscode', 'esbuild', 'lightningcss'],
   minify: true,
   outDir: 'dist',
   clean: true,


### PR DESCRIPTION
it was fine locally (with the `Run extension` launch script), it's not when published and downloaded from marketplace

just tried building the `panda.vsix` locally with `cd packages/vscode && yarn build && yarn pkg` and then drag/drop the file into the extensions, it seems ok now, let's hpoe it also is fine when published in the marketplace 😓 