### PR TITLE
ci: rm deprecated win32-ia32

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -69,9 +69,6 @@ jobs:
             target: win32-x64
             npm_config_arch: x64
           - os: windows-latest
-            target: win32-ia32
-            npm_config_arch: ia32
-          - os: windows-latest
             target: win32-arm64
             npm_config_arch: arm
           - os: ubuntu-latest


### PR DESCRIPTION
fixes the CI error: 

`Error: The provided target platform win32-ia32 is no longer supported for Visual Studio Code extensions.`
