### PR TITLE
feat(language-server): improved token parsing on utilities

### DIFF
--- a/.changeset/heavy-kiwis-clap.md
+++ b/.changeset/heavy-kiwis-clap.md
@@ -1,0 +1,5 @@
+---
+'@pandacss/language-server': minor
+---
+
+improved token parsing for utilities

--- a/packages/language-server/__tests__/get-token.test.ts
+++ b/packages/language-server/__tests__/get-token.test.ts
@@ -14,7 +14,27 @@ test('zIndex: 1', () => {
 
 test('margin: 2', () => {
   const ctx = createContext()
-  expect(getTokenFromPropValue(ctx, 'margin', '2')).toMatchInlineSnapshot(`undefined`)
+  expect(getTokenFromPropValue(ctx, 'margin', '2')).toMatchInlineSnapshot(`
+    _Token {
+      "description": undefined,
+      "extensions": {
+        "category": "spacing",
+        "condition": "base",
+        "pixelValue": "8px",
+        "prop": "2",
+        "var": "--spacing-2",
+        "varRef": "var(--spacing-2)",
+      },
+      "name": "spacing.2",
+      "originalValue": "0.5rem",
+      "path": [
+        "spacing",
+        "2",
+      ],
+      "type": "dimension",
+      "value": "0.5rem",
+    }
+  `)
 })
 
 test('CSS var', () => {
@@ -37,48 +57,48 @@ test('token reference with curly braces', () => {
   `)
 })
 
-test('composite value with token reference with token()', () => {
-  const ctx = createContext()
-  expect(getTokenFromPropValue(ctx, 'border', '1px solid {colors.gray.300}')).toMatchInlineSnapshot(`
-    _Token {
-      "description": undefined,
-      "extensions": {
-        "category": "colors",
-        "colorPalette": "gray",
-        "colorPaletteRoots": [
-          [
-            "gray",
-          ],
-        ],
-        "colorPaletteTokenKeys": [
-          [
-            "300",
-          ],
-        ],
-        "condition": "base",
-        "kind": "semantic-color",
-        "prop": "gray.300",
-        "var": "--colors-gray-300",
-        "varRef": "var(--colors-gray-300)",
-        "vscodeColor": {
-          "alpha": 1,
-          "blue": 0.8588235294117647,
-          "green": 0.8352941176470589,
-          "red": 0.8196078431372549,
-        },
-      },
-      "name": "colors.gray.300",
-      "originalValue": "#d1d5db",
-      "path": [
-        "colors",
-        "gray",
-        "300",
-      ],
-      "type": "color",
-      "value": "#d1d5db",
-    }
-  `)
-})
+// test('composite value with token reference with token()', () => {
+//   const ctx = createContext()
+//   expect(getTokenFromPropValue(ctx, 'border', '1px solid {colors.gray.300}')).toMatchInlineSnapshot(`
+//     _Token {
+//       "description": undefined,
+//       "extensions": {
+//         "category": "colors",
+//         "colorPalette": "gray",
+//         "colorPaletteRoots": [
+//           [
+//             "gray",
+//           ],
+//         ],
+//         "colorPaletteTokenKeys": [
+//           [
+//             "300",
+//           ],
+//         ],
+//         "condition": "base",
+//         "kind": "semantic-color",
+//         "prop": "gray.300",
+//         "var": "--colors-gray-300",
+//         "varRef": "var(--colors-gray-300)",
+//         "vscodeColor": {
+//           "alpha": 1,
+//           "blue": 0.8588235294117647,
+//           "green": 0.8352941176470589,
+//           "red": 0.8196078431372549,
+//         },
+//       },
+//       "name": "colors.gray.300",
+//       "originalValue": "#d1d5db",
+//       "path": [
+//         "colors",
+//         "gray",
+//         "300",
+//       ],
+//       "type": "color",
+//       "value": "#d1d5db",
+//     }
+//   `)
+// })
 
 test('token reference with token()', () => {
   const ctx = createContext()
@@ -165,6 +185,31 @@ test('color: #fff', () => {
       "path": "colors.#fff",
       "type": "color",
       "value": "#fff",
+    }
+  `)
+})
+
+test('width: xs', () => {
+  const ctx = createContext()
+  expect(getTokenFromPropValue(ctx, 'width', 'xs')).toMatchInlineSnapshot(`
+    _Token {
+      "description": undefined,
+      "extensions": {
+        "category": "sizes",
+        "condition": "base",
+        "pixelValue": "320px",
+        "prop": "xs",
+        "var": "--sizes-xs",
+        "varRef": "var(--sizes-xs)",
+      },
+      "name": "sizes.xs",
+      "originalValue": "20rem",
+      "path": [
+        "sizes",
+        "xs",
+      ],
+      "type": undefined,
+      "value": "20rem",
     }
   `)
 })

--- a/packages/language-server/__tests__/get-token.test.ts
+++ b/packages/language-server/__tests__/get-token.test.ts
@@ -57,48 +57,48 @@ test('token reference with curly braces', () => {
   `)
 })
 
-// test('composite value with token reference with token()', () => {
-//   const ctx = createContext()
-//   expect(getTokenFromPropValue(ctx, 'border', '1px solid {colors.gray.300}')).toMatchInlineSnapshot(`
-//     _Token {
-//       "description": undefined,
-//       "extensions": {
-//         "category": "colors",
-//         "colorPalette": "gray",
-//         "colorPaletteRoots": [
-//           [
-//             "gray",
-//           ],
-//         ],
-//         "colorPaletteTokenKeys": [
-//           [
-//             "300",
-//           ],
-//         ],
-//         "condition": "base",
-//         "kind": "semantic-color",
-//         "prop": "gray.300",
-//         "var": "--colors-gray-300",
-//         "varRef": "var(--colors-gray-300)",
-//         "vscodeColor": {
-//           "alpha": 1,
-//           "blue": 0.8588235294117647,
-//           "green": 0.8352941176470589,
-//           "red": 0.8196078431372549,
-//         },
-//       },
-//       "name": "colors.gray.300",
-//       "originalValue": "#d1d5db",
-//       "path": [
-//         "colors",
-//         "gray",
-//         "300",
-//       ],
-//       "type": "color",
-//       "value": "#d1d5db",
-//     }
-//   `)
-// })
+test('composite value with token reference with token()', () => {
+  const ctx = createContext()
+  expect(getTokenFromPropValue(ctx, 'border', '1px solid {colors.gray.300}')).toMatchInlineSnapshot(`
+    _Token {
+      "description": undefined,
+      "extensions": {
+        "category": "colors",
+        "colorPalette": "gray",
+        "colorPaletteRoots": [
+          [
+            "gray",
+          ],
+        ],
+        "colorPaletteTokenKeys": [
+          [
+            "300",
+          ],
+        ],
+        "condition": "base",
+        "kind": "semantic-color",
+        "prop": "gray.300",
+        "var": "--colors-gray-300",
+        "varRef": "var(--colors-gray-300)",
+        "vscodeColor": {
+          "alpha": 1,
+          "blue": 0.8588235294117647,
+          "green": 0.8352941176470589,
+          "red": 0.8196078431372549,
+        },
+      },
+      "name": "colors.gray.300",
+      "originalValue": "#d1d5db",
+      "path": [
+        "colors",
+        "gray",
+        "300",
+      ],
+      "type": "color",
+      "value": "#d1d5db",
+    }
+  `)
+})
 
 test('token reference with token()', () => {
   const ctx = createContext()


### PR DESCRIPTION
## 📝 Description

Utilities _could_ also use tokens if they pass a theme reference and key a specific category.

For example:

https://github.com/chakra-ui/panda/blob/465eb9c480be3e5ba8e232f06b346e1f1ab5b474/packages/preset-base/src/utilities/sizing.ts#L3-L5

`theme('sizes')` is passed to this utility. We can capture this value to help infer a correct token.

## ⛳️ Current behavior (updates)

Should improve utility function auto complete

## 💣 Is this a breaking change (Yes/No):

No