### PR TITLE
fix(language-server): support escape hatched colors

### DIFF
--- a/.changeset/modern-clocks-collect.md
+++ b/.changeset/modern-clocks-collect.md
@@ -1,0 +1,5 @@
+---
+'@pandacss/language-server': minor
+---
+
+handle escape hatched colors

--- a/packages/language-server/__tests__/get-token.test.ts
+++ b/packages/language-server/__tests__/get-token.test.ts
@@ -45,14 +45,42 @@ test('CSS var', () => {
 test('token reference with curly braces', () => {
   const ctx = createContext()
   expect(getTokenFromPropValue(ctx, 'border', '{colors.gray.300}')).toMatchInlineSnapshot(`
-    {
+    _Token {
+      "description": undefined,
       "extensions": {
-        "kind": "invalid-token-path",
+        "category": "colors",
+        "colorPalette": "gray",
+        "colorPaletteRoots": [
+          [
+            "gray",
+          ],
+        ],
+        "colorPaletteTokenKeys": [
+          [
+            "300",
+          ],
+        ],
+        "condition": "base",
+        "kind": "semantic-color",
+        "prop": "gray.300",
+        "var": "--colors-gray-300",
+        "varRef": "var(--colors-gray-300)",
+        "vscodeColor": {
+          "alpha": 1,
+          "blue": 0.8588235294117647,
+          "green": 0.8352941176470589,
+          "red": 0.8196078431372549,
+        },
       },
-      "name": "{colors.gray.300}",
-      "path": "borders.{colors.gray.300}",
+      "name": "colors.gray.300",
+      "originalValue": "#d1d5db",
+      "path": [
+        "colors",
+        "gray",
+        "300",
+      ],
       "type": "color",
-      "value": "{colors.gray.300}",
+      "value": "#d1d5db",
     }
   `)
 })
@@ -171,6 +199,27 @@ test('fontSize: xl', () => {
 test('color: #fff', () => {
   const ctx = createContext()
   expect(getTokenFromPropValue(ctx, 'color', '#fff')).toMatchInlineSnapshot(`
+    {
+      "extensions": {
+        "kind": "native-color",
+        "vscodeColor": {
+          "alpha": 1,
+          "blue": 1,
+          "green": 1,
+          "red": 1,
+        },
+      },
+      "name": "#fff",
+      "path": "colors.#fff",
+      "type": "color",
+      "value": "#fff",
+    }
+  `)
+})
+
+test('color: [#fff]', () => {
+  const ctx = createContext()
+  expect(getTokenFromPropValue(ctx, 'color', '[#fff]')).toMatchInlineSnapshot(`
     {
       "extensions": {
         "kind": "native-color",

--- a/packages/language-server/src/tokens/expand-token-fn.ts
+++ b/packages/language-server/src/tokens/expand-token-fn.ts
@@ -11,8 +11,8 @@ import type { Token } from '@pandacss/token-dictionary'
 /**
  * Regex for matching a tokenized reference.
  */
-const REFERENCE_REGEX = /({([^}]*)})/g
-const curlyBracketRegex = /[{}]/g
+const REFERENCE_REGEX = /({([^}]*)})/
+const curlyBracketRegex = /[{}]/
 
 /**
  * Returns all references in a string


### PR DESCRIPTION
allow escape hatch brackets when resolving a color token
fix issue where regex with global flag retains state see: https://stackoverflow.com/a/1520853/684869

Closes #38

## 📝 Description

> Add a brief description

## ⛳️ Current behavior (updates)

Escaped hatched colors `color: [red]` do not show inline hints

## 🚀 New behavior

Escape hatched colors show color value preview

![image](https://github.com/user-attachments/assets/fa11ceef-b5fa-4459-81ea-cda614191cce)

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information
